### PR TITLE
[IN-698] Add Method Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The complete AWS API Gateway Framework, powered by [Serverless Components](https
 - Extend Existing API Gateway REST APIs without disrupting other services.
 - Integrate with AWS Lambda via the [aws-lambda component](https://github.com/serverless-components/aws-lambda)
 - Authorize requests with AWS Lambda authorizers
-- Create proxy endpoints for any URL with 3 lines of code (coming soon)
+- Create proxy endpoints for any URL with 3 lines of code
 - Create mock endpoints by specifying the object you'd like to return (coming soon)
 - Debug API Gateway requests Via CloudWatch Logs (coming soon)
 - Protect your API with API Keys (coming soon)
@@ -88,7 +88,9 @@ Keep reading for info on how to set up the `serverless.yml` file.
 You can configure the component to either create a new REST API from scratch, or extend an existing one.
 
 #### Creating REST APIs
-You can create new REST APIs by specifying the endpoints you'd like to create, and optionally passing a name and description for your new REST API. You may also choose between a lambda proxy or http proxy integration by using the function or proxyURI field respectively. The function field will override the proxyURI field.
+You can create new REST APIs by specifying the endpoints you'd like to create, and optionally passing a name 
+and description for your new REST API. You may also choose between a lambda proxy, or http integration by 
+using the function or URI field respectively.
 
 ```yml
 # serverless.yml
@@ -122,10 +124,22 @@ restApi:
         method: GET
         function: ${getUsers.arn}
         authorizer: ${auth.arn}
-      - path: /users
+
+        # create a resource with a variable in the path
+      - path: /users/{ID}
         method: PUT
-        proxyURI: https://example.com/users
-        authorizer: ${auth.arn}
+        # The above path makes ID available to use in your uri
+        URI: https://example.com/users/{ID}
+        # authorizer also take a name for existing endpoints
+        authorizer: auth-dev
+        # params sets method and integration request headers and querystring parameters
+        params:
+          headers:
+            auth: true  # keys with a boolean value state whether it is required or not
+            policy: users-mod
+          querystrings:
+            name: true
+            status: active # keys with a string value creates a corresponding static variable in integration request only
 ```
 
 #### Extending REST APIs

--- a/utils.js
+++ b/utils.js
@@ -220,13 +220,46 @@ const createMethod = async ({ apig, apiId, endpoint }) => {
     authorizationType: 'NONE',
     httpMethod: endpoint.method,
     resourceId: endpoint.id,
-    restApiId: apiId,
-    apiKeyRequired: false
+    apiKeyRequired: endpoint.apiKey || true,
+    restApiId: apiId
   }
 
   if (endpoint.authorizerId) {
     params.authorizationType = 'CUSTOM'
     params.authorizerId = endpoint.authorizerId
+  }
+
+  /* create array of strings that exist inside {} in the uri path
+    starts match on } so it will match even if no opening brace */
+  const paths = endpoint.path.match(/[^{\}]+(?=})/g)
+  if (paths && paths.length) {
+    params.requestParameters = {}
+    paths.forEach(path => {
+      const key = `method.request.path.${path}`
+      params.requestParameters[key] = true
+    });
+  }
+
+  // Add headers and querystrings to method
+  if (endpoint.params) {
+    if (!params.requestParameters) params.requestParameters = {}
+    const {headers, querystrings} = endpoint.params
+
+    /* All headers and querystrings passed as static values
+      rather than booleans will not be defined in the method */
+    for (let h in headers) {
+      if (typeof headers[h] === 'boolean') {
+        const key = `method.request.header.${h}`
+        params.requestParameters[key] = headers[h]
+      }
+    }
+
+    for (let qs in querystrings) {
+      if (typeof querystrings[qs] === 'boolean') {
+        const key = `method.request.querystring.${qs}`
+        params.requestParameters[key] = querystrings[qs]
+      }
+    }
   }
 
   try {
@@ -290,6 +323,35 @@ const createIntegration = async ({ apig, lambda, apiId, endpoint }) => {
     uri: isLambda
       ? `arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${endpoint.function}/invocations`
       : endpoint.proxyURI
+  }
+
+  // create array of strings that exist inside {} in the uri path
+  // starts match on } so it will match even if no opening brace
+  const paths = endpoint.path.match(/[^{\}]+(?=})/g)
+  if (paths && paths.length) {
+    integrationParams.requestParameters = {}
+    paths.forEach(path => {
+      const key = `integration.request.path.${path}`
+      const value = `method.request.path.${path}`
+      integrationParams.requestParameters[key] = value
+    });
+  }
+
+  // Add headers and querystrings to integration
+  if (endpoint.params) {
+    if (!integrationParams.requestParameters) integrationParams.requestParameters = {}
+    const { headers, querystrings } = endpoint.params
+    for (let h in headers) {
+      const key = `integration.request.header.${h}`
+      const value = typeof headers[h] === 'boolean' ? `method.request.header.${h}` : `'${headers[h]}'`
+      integrationParams.requestParameters[key] = value
+    }
+
+    for (let qs in querystrings) {
+      const key = `integration.request.querystring.${qs}`
+      const value = typeof querystrings[qs] === 'boolean' ? `method.request.querystring.${qs}` : `'${querystrings[qs]}'`
+      integrationParams.requestParameters[key] = value
+    }
   }
 
   try {


### PR DESCRIPTION
Allow user to input request params that effect putIntegration and putMethod. Request parameters are made from the path variable and a params object in the serverless.yml of the form:

```yml
path: /request/{ID}
params:
    headers:
      key1: true
      key2: value1
    querystrings:
       key3: true
       key4: value2
```

ID will show up as a path parameter in both method and integration request. A key with a boolean value links the integration request value to the value found in the method and sets it to required or not. A key with a string value is a static value and only shows up in the integration request.